### PR TITLE
Fix invalid credentials for superadmin

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -36,8 +36,10 @@ export async function POST(request: NextRequest) {
     const user = results[0]
 
     // Fallback: accept default demo password if hash missing or column absent
-    const storedHash = (user as any).password_hash || '$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi'
-    const isValidPassword = await bcrypt.compare(password, storedHash)
+    // Use provided Laravel-style hash for "password123" and normalize $2y$ -> $2a$ for bcryptjs
+    const storedHash = (user as any).password_hash || '$2y$10$2LsVYo6Mid1LkohJdUDMeeLKvS5eiU5MsP/mnouNEJSRQAbQgLcPC'
+    const normalizedHash = storedHash.startsWith('$2y$') ? storedHash.replace(/^\$2y\$/, '$2a$') : storedHash
+    const isValidPassword = await bcrypt.compare(password, normalizedHash)
     if (!isValidPassword) {
       return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 })
     }

--- a/lib/migration.ts
+++ b/lib/migration.ts
@@ -190,9 +190,11 @@ const migrations: Migration[] = [
       -- Add secure auth and richer product fields
       ALTER TABLE users ADD COLUMN IF NOT EXISTS password_hash VARCHAR(255) NULL;
       
-      -- Seed default password hash ("password") for existing demo users if missing
+      -- Seed default password hash for demo users if missing
+      -- Using Laravel-style hash ($2y) compatible with bcryptjs compare via $2a normalization
+      -- Plaintext intended: "password123"
       UPDATE users 
-      SET password_hash = '$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi'
+      SET password_hash = '$2y$10$2LsVYo6Mid1LkohJdUDMeeLKvS5eiU5MsP/mnouNEJSRQAbQgLcPC'
       WHERE password_hash IS NULL;
 
       -- Categories metadata

--- a/supabase/migrations/20251005100000_add_user_password_hash.sql
+++ b/supabase/migrations/20251005100000_add_user_password_hash.sql
@@ -19,9 +19,9 @@ BEGIN
   END IF;
 END $$;
 
--- Backfill with bcrypt hash for "password"
+-- Backfill with bcrypt hash for "password123" (Laravel-style $2y)
 UPDATE public.users
-SET password_hash = '$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi'
+SET password_hash = '$2y$10$2LsVYo6Mid1LkohJdUDMeeLKvS5eiU5MsP/mnouNEJSRQAbQgLcPC'
 WHERE password_hash IS NULL;
 
 -- Set NOT NULL constraint if safe

--- a/supabase/seed/20251003121500_seed_pos_data.sql
+++ b/supabase/seed/20251003121500_seed_pos_data.sql
@@ -2,9 +2,9 @@
 -- Users (no passwords here; manage auth via Supabase Auth separately)
 INSERT INTO users (id, email, name, role, password_hash)
 VALUES
-  (uuid_generate_v4(), 'superadmin@familystore.com', 'Super Admin', 'super_admin', '$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi'),
-  (uuid_generate_v4(), 'admin@familystore.com', 'Admin Store', 'admin', '$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi'),
-  (uuid_generate_v4(), 'kasir1@familystore.com', 'Kasir Satu', 'kasir', '$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi')
+  (uuid_generate_v4(), 'superadmin@familystore.com', 'Super Admin', 'super_admin', '$2y$10$2LsVYo6Mid1LkohJdUDMeeLKvS5eiU5MsP/mnouNEJSRQAbQgLcPC'),
+  (uuid_generate_v4(), 'admin@familystore.com', 'Admin Store', 'admin', '$2y$10$2LsVYo6Mid1LkohJdUDMeeLKvS5eiU5MsP/mnouNEJSRQAbQgLcPC'),
+  (uuid_generate_v4(), 'kasir1@familystore.com', 'Kasir Satu', 'kasir', '$2y$10$2LsVYo6Mid1LkohJdUDMeeLKvS5eiU5MsP/mnouNEJSRQAbQgLcPC')
 ON CONFLICT (email) DO NOTHING;
 
 -- Categories

--- a/supabase/seed/20251005100500_backfill_user_password_hash.sql
+++ b/supabase/seed/20251005100500_backfill_user_password_hash.sql
@@ -1,4 +1,4 @@
 -- Backfill password_hash for any users missing a hash (Postgres/Supabase)
 UPDATE public.users
-SET password_hash = '$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi'
+SET password_hash = '$2y$10$2LsVYo6Mid1LkohJdUDMeeLKvS5eiU5MsP/mnouNEJSRQAbQgLcPC'
 WHERE password_hash IS NULL;


### PR DESCRIPTION
Enable login with Laravel-style `$2y$` bcrypt hashes and synchronize demo user passwords to 'password123' to fix 'Invalid credentials' errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-8fffdac5-085a-448d-873d-05606e9e21f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8fffdac5-085a-448d-873d-05606e9e21f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

