### PR TITLE
Handle database connection errors

### DIFF
--- a/lib/migration.ts
+++ b/lib/migration.ts
@@ -210,7 +210,19 @@ const migrations: Migration[] = [
   },
 ]
 
+function isSupabaseConfigured(): boolean {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL
+  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY
+  const service = process.env.SUPABASE_SERVICE_ROLE_KEY
+  return Boolean(url && (anon || service))
+}
+
 export async function runMigrations() {
+  // Skip MySQL migrations when Supabase is configured
+  if (isSupabaseConfigured() && process.env.ALLOW_MYSQL_MIGRATIONS !== "1") {
+    console.log("[v0] Supabase detected - skipping MySQL migrations")
+    return
+  }
   try {
     console.log("[v0] Starting database migrations...")
 


### PR DESCRIPTION
Add guards to prevent MySQL connections and migrations when Supabase is configured, resolving `ECONNREFUSED` errors and enforcing Supabase-only usage by default.

---
<a href="https://cursor.com/background-agent?bcId=bc-fba7bfe2-b66d-4c4f-b413-31b3bdef1b1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fba7bfe2-b66d-4c4f-b413-31b3bdef1b1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

