### PR TITLE
Process empty error messages

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { initializeDatabase } from '@/lib/mysql-service'
 import bcrypt from 'bcryptjs'
+import { getErrorMessage } from '@/lib/utils'
 
 export async function POST(request: NextRequest) {
   try {
@@ -52,12 +53,12 @@ export async function POST(request: NextRequest) {
     })
   } catch (error) {
     console.error('Login error:', error)
-    const message = error instanceof Error ? error.message : 'Internal server error'
+    const message = getErrorMessage(error, 'Internal server error')
     const lower = message.toLowerCase()
     const isDbUnavailable =
       lower.includes('econnrefused') ||
       lower.includes('tidak dapat terhubung ke mysql') ||
       lower.includes('timeout')
-    return NextResponse.json({ error: message }, { status: isDbUnavailable ? 503 : 500 })
+    return NextResponse.json({ error: message || 'Internal server error' }, { status: isDbUnavailable ? 503 : 500 })
   }
 }

--- a/app/api/supabase/health/route.ts
+++ b/app/api/supabase/health/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server"
 import { supabase } from "@/lib/supabase"
+import { getErrorMessage } from "@/lib/utils"
 
 export async function GET() {
   try {
@@ -8,12 +9,15 @@ export async function GET() {
 
     const { error } = await supabase.from("users").select("id").limit(1)
     if (error) {
-      return NextResponse.json({ ok: false, hasEnv: { url: hasUrl, key: hasKey }, error: error.message }, { status: 500 })
+      return NextResponse.json(
+        { ok: false, hasEnv: { url: hasUrl, key: hasKey }, error: getErrorMessage(error, "Supabase error") },
+        { status: 500 }
+      )
     }
     return NextResponse.json({ ok: true, hasEnv: { url: hasUrl, key: hasKey } })
   } catch (e) {
-    const message = e instanceof Error ? e.message : "Unknown error"
-    return NextResponse.json({ ok: false, error: message }, { status: 500 })
+    const message = getErrorMessage(e, "Unknown error")
+    return NextResponse.json({ ok: false, error: message || "Unknown error" }, { status: 500 })
   }
 }
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -32,3 +32,77 @@ export function formatTime(dateOrString: Date | string): string {
     minute: "2-digit",
   }).format(date)
 }
+
+/**
+ * Safely derive a human-readable, non-empty error message from any thrown value.
+ * Falls back to the provided default when the source message is empty or missing.
+ */
+export function getErrorMessage(error: unknown, fallback: string = "Internal server error"): string {
+  if (error === null || error === undefined) return fallback
+
+  // String errors
+  if (typeof error === "string") {
+    const trimmed = error.trim()
+    return trimmed || fallback
+  }
+
+  // Native Error instances
+  if (error instanceof Error) {
+    const directMessage = (error.message || "").trim()
+    if (directMessage) return directMessage
+
+    // Some libraries populate additional fields
+    const sqlMessage = (error as any).sqlMessage
+    if (typeof sqlMessage === "string" && sqlMessage.trim()) return sqlMessage.trim()
+
+    const details = (error as any).details ?? (error as any).detail
+    if (typeof details === "string" && details.trim()) return details.trim()
+
+    // Attempt to read from cause chain
+    const cause = (error as any).cause
+    if (cause) {
+      const causeMessage = getErrorMessage(cause, "")
+      if (causeMessage) return causeMessage
+    }
+
+    const name = (error.name || "").trim()
+    if (name && name.toLowerCase() !== "error") return name
+
+    return fallback
+  }
+
+  // Plain objects (e.g., API error objects)
+  if (typeof error === "object") {
+    const err = error as Record<string, unknown>
+    const candidates: unknown[] = [
+      err.message,
+      (err as any).error_description,
+      (err as any).error,
+      (err as any).reason,
+    ]
+    for (const candidate of candidates) {
+      if (typeof candidate === "string") {
+        const trimmed = candidate.trim()
+        if (trimmed) return trimmed
+      }
+    }
+
+    // Nested error shapes: { error: { message: "..." } }
+    const nestedError = (err as any).error
+    if (nestedError && typeof nestedError === "object") {
+      const nested = getErrorMessage(nestedError, "")
+      if (nested) return nested
+    }
+
+    // Arrays of errors: { errors: [ { message: "..." } ] }
+    const errorsArray = (err as any).errors
+    if (Array.isArray(errorsArray)) {
+      for (const item of errorsArray) {
+        const itemMessage = getErrorMessage(item, "")
+        if (itemMessage) return itemMessage
+      }
+    }
+  }
+
+  return fallback
+}


### PR DESCRIPTION
Add a robust `getErrorMessage` helper and integrate it into API routes to prevent empty error responses.

---
<a href="https://cursor.com/background-agent?bcId=bc-175c4354-ca01-4f9e-8a72-4befcc1cc398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-175c4354-ca01-4f9e-8a72-4befcc1cc398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

