### PR TITLE
Handle invalid login credentials

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -23,7 +23,11 @@ export async function POST(request: NextRequest) {
 
     const user = userRow
     const storedHash = user.password_hash || '$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi'
-    const isValidPassword = await bcrypt.compare(password, storedHash)
+    // Normalize PHP's $2y$ prefix to $2a$ for broad bcrypt compatibility
+    const normalizedHash = storedHash.startsWith('$2y$')
+      ? '$2a$' + storedHash.slice(4)
+      : storedHash
+    const isValidPassword = await bcrypt.compare(password, normalizedHash)
     if (!isValidPassword) {
       return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 })
     }

--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -71,8 +71,8 @@ export function LoginForm() {
             <p className="font-medium">Demo Akun:</p>
             <p>Super Admin: superadmin@familystore.com</p>
             <p>Admin: admin@familystore.com</p>
-            <p>Kasir: kasir@familystore.com</p>
-            <p className="text-xs mt-1">Password: password123</p>
+            <p>Kasir: kasir1@familystore.com</p>
+            <p className="text-xs mt-1">Password: password</p>
           </div>
         </CardContent>
       </Card>


### PR DESCRIPTION
Normalize PHP-style bcrypt hashes for login and update demo credentials.

The login API was failing for users whose `password_hash` in the database was generated with PHP's bcrypt, as these hashes start with `$2y$` instead of the `$2a$` prefix expected by the Node.js `bcrypt` library. This change ensures compatibility. Additionally, the demo credentials displayed on the login form were outdated, leading to confusion.

---
<a href="https://cursor.com/background-agent?bcId=bc-213ef5d7-3e3e-455c-b70f-b7448d381b2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-213ef5d7-3e3e-455c-b70f-b7448d381b2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

